### PR TITLE
Send `source` when posting an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Full changelog for the Costs to Expect web app.
 
+## 2019-07-10 - v1.04.4
+
+* Updated the `postError` request, sends the `source` field which is required for the API ^=1.16.1. 
+
 ## 2019-05-30 - v1.04.3
 
 * Updated FE dependencies, Jquery and Popper.

--- a/app/Request/Api.php
+++ b/app/Request/Api.php
@@ -309,7 +309,8 @@ class Api
                         'method' => $method,
                         'expected_status_code' => $expected_status_code,
                         'returned_status_code' => $returned_status_code,
-                        'request_uri' => $request_uri
+                        'request_uri' => $request_uri,
+                        'source' => 'legacy'
                     ]
                 ]
             );

--- a/config/web/config.php
+++ b/config/web/config.php
@@ -43,6 +43,6 @@ return [
     'api_category_id_non_essentials' => env($key_api_category_non_essentials, null),
     'api_category_id_hobbies_and_interests' => env($key_api_category_hobbies, null),
 
-    'version' => 'v1.04.3',
-    'release_date' => '30th May 2019'
+    'version' => 'v1.04.4',
+    'release_date' => '10th July 2019'
 ];


### PR DESCRIPTION
- Updated the `postError` request, sends the `source` field which is required for the API ^=1.16.1.
- Updated CHANGELOG